### PR TITLE
Use official node alpine as base image instead of building from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,6 @@
-FROM alpine:3.5
+FROM node:7-alpine
 
 MAINTAINER Armagan Amcalar "armagan@amcalar.com"
-
-# ENV VERSION=v0.10.48 CFLAGS="-D__USE_MISC" NPM_VERSION=2
-# ENV VERSION=v0.12.17 NPM_VERSION=2
-# ENV VERSION=v4.7.0 NPM_VERSION=2
-# ENV VERSION=v6.9.2 NPM_VERSION=3
-# ENV VERSION=v7.3.0 NPM_VERSION=3
-ENV VERSION=v7.7.1 NPM_VERSION=4
-
-# For base builds
-# ENV CONFIG_FLAGS="--without-npm" RM_DIRS=/usr/include
-# ENV CONFIG_FLAGS="--fully-static --without-npm" DEL_PKGS="libgcc libstdc++" RM_DIRS=/usr/include
 
 ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_MINOR=92 \
@@ -20,46 +9,11 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_HOME=/opt/jdk \
     PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
-    LANG=C.UTF-8
-
-# Node.js build
-RUN apk add --no-cache curl make gcc g++ python linux-headers paxctl libgcc libstdc++ gnupg && \
-  gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B && \
-  gpg --keyserver pool.sks-keyservers.net --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5 && \
-  gpg --keyserver pool.sks-keyservers.net --recv-keys 0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 && \
-  gpg --keyserver pool.sks-keyservers.net --recv-keys FD3A5288F042B6850C66B31F09FE44734EB7990E && \
-  gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 && \
-  gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D && \
-  gpg --keyserver pool.sks-keyservers.net --recv-keys C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 && \
-  gpg --keyserver pool.sks-keyservers.net --recv-keys B9AE9905FFD7803F25714661B63B535A4C206CA9 && \
-  curl -o node-${VERSION}.tar.gz -sSL https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.gz && \
-  curl -o SHASUMS256.txt.asc -sSL https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc && \
-  gpg --verify SHASUMS256.txt.asc && \
-  grep node-${VERSION}.tar.gz SHASUMS256.txt.asc | sha256sum -c - && \
-  tar -zxf node-${VERSION}.tar.gz && \
-  cd node-${VERSION} && \
-  export GYP_DEFINES="linux_use_gold_flags=0" && \
-  ./configure --prefix=/usr ${CONFIG_FLAGS} && \
-  NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
-  make -j${NPROC} -C out mksnapshot BUILDTYPE=Release && \
-  paxctl -cm out/Release/mksnapshot && \
-  make -j${NPROC} && \
-  make install && \
-  paxctl -cm /usr/bin/node && \
-  cd / && \
-  if [ -x /usr/bin/npm ]; then \
-    npm install -g npm@${NPM_VERSION} && \
-    find /usr/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf; \
-  fi && \
-  apk del curl make gcc g++ python linux-headers paxctl gnupg ${DEL_PKGS} && \
-  rm -rf /etc/ssl /node-${VERSION}.tar.gz /SHASUMS256.txt.asc /node-${VERSION} ${RM_DIRS} \
-    /usr/share/man /tmp/* /var/cache/apk/* /root/.npm /root/.node-gyp /root/.gnupg \
-    /usr/lib/node_modules/npm/man /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/html && \
+    LANG=C.UTF-8 \
+    NPM_CONFIG_LOGLEVEL=warn
 
 # build tools
-  apk add --update python python-dev build-base bash git curl ca-certificates openssh-client rsync && \
-    echo http://dl-4.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
-    apk add --no-cache mongodb && \
+RUN apk add --update python python-dev build-base bash git curl ca-certificates openssh-client rsync && \
     for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
     apk add --allow-untrusted /tmp/*.apk && \
     rm -v /tmp/*.apk && \
@@ -74,7 +28,7 @@ RUN apk add --no-cache curl make gcc g++ python linux-headers paxctl libgcc libs
     ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
     find /opt/jdk/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
     cd /opt/jdk/ && ln -s ./jre/bin ./bin && \
-    npm install -g bower gulp-cli ava yarn && \
+    npm install -g bower gulp-cli ava && \
     mkdir -p /data/db && \
 
     rm -rf /usr/share/man /tmp/* /var/cache/apk/* /root/.npm /root/.node-gyp \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 This is a docker image that includes various build tools for Node.js projects.
 
-This image is based on alpine:3.5 and includes git, MongoDB, Node.js 7.7.1, Java 8, npm, yarn, bower, gulp, AVA, python and rsync.
+This image is based on node:7-alpine and includes git, Node.js 7, Java 8, npm, yarn, bower, gulp, AVA, python and rsync.
 
-Basic bits are taken from https://github.com/mhart/alpine-node
 Java bits are taken from https://github.com/anapsix/docker-alpine-java


### PR DESCRIPTION
Cannot compile MongoDB on alpine 3.4 (it is included only in edge)
Decided to remove it as it should not be a build time dependency anyway.